### PR TITLE
BN_generate_prime -> BN_generate_prime_ex

### DIFF
--- a/src/primemodule.c
+++ b/src/primemodule.c
@@ -26,6 +26,11 @@ static PyObject * gensafeprime_generate(PyObject *self, PyObject *args) {
 
 	// Generate the prime
 	n = BN_new();
+	if (n == NULL) {
+		PyErr_SetString(PyExc_RuntimeError, "call to BN_new failed");
+		return NULL;
+	}
+
 	if (BN_generate_prime_ex(n, bitlength, 1, NULL, NULL, NULL) != 1) {
 		BN_free(n);
 		PyErr_SetString(PyExc_RuntimeError, "call to BN_generate_prime_ex failed");

--- a/src/primemodule.c
+++ b/src/primemodule.c
@@ -25,9 +25,10 @@ static PyObject * gensafeprime_generate(PyObject *self, PyObject *args) {
 	}
 
 	// Generate the prime
-	n = BN_generate_prime(NULL, bitlength, 1, NULL, NULL, NULL, NULL);
-	if (n == NULL) {
-		PyErr_SetString(PyExc_RuntimeError, "call to BN_generate_prime failed");
+	n = BN_new();
+	if (BN_generate_prime_ex(n, bitlength, 1, NULL, NULL, NULL) != 1) {
+		BN_free(n);
+		PyErr_SetString(PyExc_RuntimeError, "call to BN_generate_prime_ex failed");
 		return NULL;
 	}
 


### PR DESCRIPTION
Seems BN_generate_prime() doesn't work with OpenSSL 1.1.1 anymore (I got "call to BN_generate_prime failed" all the time). That function was marked as deprecated long ago. Quick fix to make gensafeprime usable again, hope it's ok.